### PR TITLE
Remove deprecated Line Notify feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Send simple message via channel's RESTful API.
 
 Support channels:
 - Telegram
-- Line Notify
 - Hangouts Chat
 - Slack
 - Discord
@@ -33,25 +32,6 @@ References:
 
 - [從零開始的 Telegram Bot](https://blog.sean.taipei/2017/05/telegram-bot)
 - [用 Docker Multi-Stage 編譯出 Go 語言最小 Image](https://blog.wu-boy.com/2017/04/build-minimal-docker-container-using-multi-stage-for-go-app/)
-
-## Line Notify
-
-Send notify message to Line Notify
-
-```
-docker run \
-  -e NOTIFY_LINE_NOTIFY_TOKEN="$NOTIFY_LINE_NOTIFY_TOKEN" \
-  ghcr.io/timfanda35/simple-channel-notify \
-  linenotify --message="Notify Message~~~"
-```
-
-Environment Variables
-- `NOTIFY_LINE_NOTIFY_TOKEN`
-
-References:
-
-- [LINE Notify API Document](https://notify-bot.line.me/doc/en/)
-- [自建 LINE Notify 訊息通知](https://www.oxxostudio.tw/articles/201806/line-notify.html)
 
 ## Hangouts Chat
 

--- a/main.go
+++ b/main.go
@@ -50,41 +50,6 @@ func notifyTelegram(message string) {
 }
 
 /*
-	# Line Notify
-
-	Parameters:
-	- message
-
-  Environment variables:
-  - NOTIFY_LINE_NOTIFY_TOKEN
-*/
-func notifyLineNotify(message string) {
-	// Load environment variables
-	lineNotifyToken, ok := os.LookupEnv("NOTIFY_LINE_NOTIFY_TOKEN")
-	if !ok {
-		log.Fatal("NOTIFY_LINE_NOTIFY_TOKEN environment variable is unset")
-	}
-
-	endpoint := "https://notify-api.line.me/api/notify"
-	data := url.Values{"message": {message}}
-	body := strings.NewReader(data.Encode())
-
-	req, err := http.NewRequest("POST", endpoint, body)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", lineNotifyToken))
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		panic(err)
-	}
-	defer resp.Body.Close()
-
-	ioutil.ReadAll(resp.Body)
-	log.Print("Line Notify notified")
-}
-
-/*
 	# Hangouts Chat
 
 	Parameters:
@@ -185,9 +150,6 @@ func main() {
 	telegramCmd := flag.NewFlagSet("telegram", flag.ExitOnError)
 	telegramMessage := telegramCmd.String("message", "This is a test message", "message")
 
-	lineNotifyCmd := flag.NewFlagSet("linenotify", flag.ExitOnError)
-	lineNotifyMessage := lineNotifyCmd.String("message", "This is a test message", "message")
-
 	hangoutsChatCmd := flag.NewFlagSet("hangoutschat", flag.ExitOnError)
 	hangoutsChatMessage := hangoutsChatCmd.String("message", "This is a test message", "message")
 
@@ -198,7 +160,7 @@ func main() {
 	discordMessage := discordCmd.String("message", "This is a test message", "message")
 
 	if len(os.Args) < 2 {
-		log.Println("Expected 'telegram', 'linenotify', 'hangoutschat', 'slack', or 'discord'")
+		log.Println("Expected 'telegram', 'hangoutschat', 'slack', or 'discord'")
 		os.Exit(1)
 	}
 
@@ -206,9 +168,6 @@ func main() {
 	case "telegram":
 		telegramCmd.Parse(os.Args[2:])
 		notifyTelegram(*telegramMessage)
-	case "linenotify":
-		lineNotifyCmd.Parse(os.Args[2:])
-		notifyLineNotify(*lineNotifyMessage)
 	case "hangoutschat":
 		hangoutsChatCmd.Parse(os.Args[2:])
 		notifyHangoutsChat(*hangoutsChatMessage)
@@ -219,7 +178,7 @@ func main() {
 		discordCmd.Parse(os.Args[2:])
 		notifyDiscord(*discordMessage)
 	default:
-		log.Println("Expected 'telegram', 'linenotify', 'hangoutschat', 'slack', or 'discord'")
+		log.Println("Expected 'telegram', 'hangoutschat', 'slack', or 'discord'")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This commit removes the Line Notify functionality, including:
- The `notifyLineNotify` function in `main.go`.
- Command-line flag parsing and the switch case for `linenotify` in `main.go`.
- The "Line Notify" section from `README.md`.